### PR TITLE
'make test' keeps running bin/buildout every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: bin/django var/db.sqlite3
 
-bin/django: cleanpyc var/assets/jquery/bower.json bin/buildout buildout.cfg versions.cfg setup.py
+bin/django: var/assets/jquery/bower.json bin/buildout buildout.cfg versions.cfg setup.py
 	bin/buildout
 	touch -c $@
 
@@ -47,7 +47,7 @@ cleanpyc:
 run: bin/django
 	bin/django runserver 0.0.0.0:8000
 
-test: bin/django flake8
+test: bin/django flake8 cleanpyc
 	bin/django test akllt
 
 flake8: bin/flake8


### PR DESCRIPTION
1. Run 'make test'
2. Run 'make test' again

Expectation: since buildout.cfg didn't change, and neither did setup.py, nor anything actually, there's no reason to run bin/buildout again and so it shouldn't.

What happens instead: bin/buildout runs every time and slows down the test loop.
